### PR TITLE
✨[cqhttp]新增自身消息事件以及在toml中可以添加一个`debug`配置

### DIFF
--- a/docs/guide/basic-config.md
+++ b/docs/guide/basic-config.md
@@ -54,7 +54,7 @@ adapter_type = "reverse-ws"
 host = "127.0.0.1"
 port = 8080
 url = "/cqhttp/ws"
-
+debug = false
 ```
 
 你可以写入任意未被定义的配置项，它们同样会被 AliceBot 加载，这些自定义配置可以用于插件中，如你可以通过定义 `superuser` 来表示控制当前当前机器的特殊用户，或者用 `nickname` 表示当前机器人的昵称。

--- a/packages/alicebot-adapter-cqhttp/alicebot/adapter/cqhttp/__init__.py
+++ b/packages/alicebot-adapter-cqhttp/alicebot/adapter/cqhttp/__init__.py
@@ -8,10 +8,9 @@ import json
 import time
 import asyncio
 from functools import partial
-from typing import TYPE_CHECKING, Any, Dict, Literal, Callable, Awaitable
+from typing import TYPE_CHECKING, Any, Dict, Literal
 
 import aiohttp
-from aiohttp import web
 
 from alicebot.utils import DataclassEncoder
 from alicebot.adapter.utils import WebSocketAdapter
@@ -19,14 +18,8 @@ from alicebot.log import logger, error_or_exception
 
 from .config import Config
 from .message import CQHTTPMessage
+from .event import CQHTTPEvent, get_event_class
 from .exceptions import ApiTimeout, ActionFailed, NetworkError, ApiNotAvailable
-from .event import (
-    MetaEvent,
-    CQHTTPEvent,
-    HeartbeatMetaEvent,
-    LifecycleMetaEvent,
-    get_event_class,
-)
 
 if TYPE_CHECKING:
     from .message import T_CQMSG
@@ -40,19 +33,18 @@ class CQHTTPAdapter(WebSocketAdapter[CQHTTPEvent, Config]):
     name = "cqhttp"
     Config = Config
 
-    _api_response: Dict[str, Any]
-    _api_response_cond: asyncio.Condition
+    _api_response: Dict[Any, Any]
+    _api_response_cond: asyncio.Condition = None
     _api_id: int = 0
 
-    def __getattr__(self, item: str) -> Callable[..., Awaitable[Any]]:
+    def __getattr__(self, item):
         return partial(self.call_api, item)
 
     async def startup(self):
         """初始化适配器。"""
-        adapter_type = self.config.adapter_type
-        if adapter_type == "ws-reverse":
-            adapter_type = "reverse-ws"
-        self.adapter_type = adapter_type
+        self.adapter_type = self.config.adapter_type
+        if self.adapter_type == "ws-reverse":
+            self.adapter_type = "reverse-ws"
         self.host = self.config.host
         self.port = self.config.port
         self.url = self.config.url
@@ -64,7 +56,6 @@ class CQHTTPAdapter(WebSocketAdapter[CQHTTPEvent, Config]):
         """反向 WebSocket 连接建立时的钩子函数。"""
         logger.info(f"WebSocket connected!")
         if self.config.access_token:
-            assert isinstance(self.websocket, web.WebSocketResponse)
             if (
                 self.websocket.headers.get("Authorization", "")
                 != f"Bearer {self.config.access_token}"
@@ -73,7 +64,6 @@ class CQHTTPAdapter(WebSocketAdapter[CQHTTPEvent, Config]):
 
     async def websocket_connect(self):
         """创建正向 WebSocket 连接。"""
-        assert self.session is not None
         logger.info("Tying to connect to WebSocket server...")
         async with self.session.ws_connect(
             f"ws://{self.host}:{self.port}/",
@@ -95,6 +85,10 @@ class CQHTTPAdapter(WebSocketAdapter[CQHTTPEvent, Config]):
                     self.bot.config.bot.log.verbose_exception,
                 )
                 return
+
+            # 便于检查事件类型
+            if self.config.debug:
+                logger.info(msg_dict)
 
             if "post_type" in msg_dict:
                 await self.handle_cqhttp_event(msg_dict)
@@ -120,9 +114,13 @@ class CQHTTPAdapter(WebSocketAdapter[CQHTTPEvent, Config]):
             msg: 接收到的信息。
         """
         post_type = msg.get("post_type")
-        assert type(post_type) is str
-        event_type = msg.get(post_type + "_type")
-        assert type(event_type) is str
+
+        # message_sent 自身消息处理
+        if post_type == "message_sent":
+            event_type = msg.get("message_type")
+        else:
+            event_type = msg.get(post_type + "_type")
+
         sub_type = msg.get("sub_type", None)
         event_class = get_event_class(post_type, event_type, sub_type)
 
@@ -130,16 +128,15 @@ class CQHTTPAdapter(WebSocketAdapter[CQHTTPEvent, Config]):
 
         if cqhttp_event.post_type == "meta_event":
             # meta_event 不交由插件处理
-            assert isinstance(cqhttp_event, MetaEvent)
-            if cqhttp_event.meta_event_type == "lifecycle":
-                assert isinstance(cqhttp_event, LifecycleMetaEvent)
-                if cqhttp_event.sub_type == "connect":
-                    logger.info(
-                        f"WebSocket connection "
-                        f"from CQHTTP Bot {msg.get('self_id')} accepted!"
-                    )
+            if (
+                cqhttp_event.meta_event_type == "lifecycle"
+                and cqhttp_event.sub_type == "connect"
+            ):
+                logger.info(
+                    f"WebSocket connection "
+                    f"from CQHTTP Bot {msg.get('self_id')} accepted!"
+                )
             elif cqhttp_event.meta_event_type == "heartbeat":
-                assert isinstance(cqhttp_event, HeartbeatMetaEvent)
                 if cqhttp_event.status.good and cqhttp_event.status.online:
                     pass
                 else:
@@ -149,8 +146,8 @@ class CQHTTPAdapter(WebSocketAdapter[CQHTTPEvent, Config]):
         else:
             await self.handle_event(cqhttp_event)
 
-    async def call_api(self, api: str, **params: Any) -> Any:
-        """调用 CQHTTP API ，协程会等待直到获得 API 响应。
+    async def call_api(self, api: str, **params) -> Dict[str, Any]:
+        """调用 CQHTTP API，协程会等待直到获得 API 响应。
 
         Args:
             api: API 名称。
@@ -161,8 +158,8 @@ class CQHTTPAdapter(WebSocketAdapter[CQHTTPEvent, Config]):
 
         Raises:
             NetworkError: 网络错误。
-            ApiNotAvailable: API 请求响应 404 ， API 不可用。
-            ActionFailed: API 请求响应 failed ， API 操作失败。
+            ApiNotAvailable: API 请求响应 404， API 不可用。
+            ActionFailed: API 请求响应 failed， API 操作失败。
             ApiTimeout: API 请求响应超时。
         """
         api_echo = self._get_api_echo()
@@ -200,7 +197,7 @@ class CQHTTPAdapter(WebSocketAdapter[CQHTTPEvent, Config]):
 
     async def send(
         self, message_: "T_CQMSG", message_type: Literal["private", "group"], id_: int
-    ) -> Any:
+    ) -> Dict[str, Any]:
         """发送消息，调用 send_private_msg 或 send_group_msg API 发送消息。
 
         Args:
@@ -208,7 +205,7 @@ class CQHTTPAdapter(WebSocketAdapter[CQHTTPEvent, Config]):
                 'CQHTTPMessageSegment', 'CQHTTPMessage'。
                 将使用 `CQHTTPMessage` 进行封装。
             message_type: 消息类型。应该是 private 或者 group。
-            id_: 发送对象的 ID ， QQ 号码或者群号码。
+            id_: 发送对象的 ID ，QQ 号码或者群号码。
 
         Returns:
             API 响应。

--- a/packages/alicebot-adapter-cqhttp/alicebot/adapter/cqhttp/config.py
+++ b/packages/alicebot-adapter-cqhttp/alicebot/adapter/cqhttp/config.py
@@ -25,3 +25,4 @@ class Config(ConfigModel):
     reconnect_interval: int = 3
     api_timeout: int = 1000
     access_token: str = ""
+    debug: bool = False

--- a/packages/alicebot-adapter-cqhttp/alicebot/adapter/cqhttp/exceptions.py
+++ b/packages/alicebot-adapter-cqhttp/alicebot/adapter/cqhttp/exceptions.py
@@ -1,6 +1,4 @@
 """CQHTTP 适配器异常。"""
-from typing import Any, Dict
-
 from alicebot.exceptions import AdapterException
 
 
@@ -15,7 +13,7 @@ class NetworkError(CQHTTPException):
 class ActionFailed(CQHTTPException):
     """API 请求成功响应，但响应表示 API 操作失败。"""
 
-    def __init__(self, resp: Dict[str, Any]):
+    def __init__(self, resp):
         """
         Args:
             resp: 返回的响应。
@@ -24,7 +22,7 @@ class ActionFailed(CQHTTPException):
 
 
 class ApiNotAvailable(ActionFailed):
-    """API 请求返回 404 ，表示当前请求的 API 不可用或不存在。"""
+    """API 请求返回 404，表示当前请求的 API 不可用或不存在。"""
 
 
 class ApiTimeout(CQHTTPException):

--- a/packages/alicebot-adapter-cqhttp/alicebot/adapter/cqhttp/message.py
+++ b/packages/alicebot-adapter-cqhttp/alicebot/adapter/cqhttp/message.py
@@ -1,16 +1,12 @@
 """CQHTTP 适配器消息。"""
-from typing import Any, Type, Union, Literal, Mapping, Iterable, Optional
+from typing import Type, Union, Literal, Mapping, Iterable, Optional
 
 from alicebot.message import Message, MessageSegment
 
 __all__ = ["T_CQMSG", "CQHTTPMessage", "CQHTTPMessageSegment", "escape"]
 
 T_CQMSG = Union[
-    str,
-    Mapping[str, Any],
-    Iterable[Mapping[str, Any]],
-    "CQHTTPMessageSegment",
-    "CQHTTPMessage",
+    str, Mapping, Iterable[Mapping], "CQHTTPMessageSegment", "CQHTTPMessage"
 ]
 
 
@@ -21,7 +17,7 @@ class CQHTTPMessage(Message["CQHTTPMessageSegment"]):
     def _message_segment_class(self) -> Type["CQHTTPMessageSegment"]:
         return CQHTTPMessageSegment
 
-    def _str_to_message_segment(self, msg: str) -> "CQHTTPMessageSegment":
+    def _str_to_message_segment(self, msg) -> "CQHTTPMessageSegment":
         return CQHTTPMessageSegment.text(msg)
 
 
@@ -226,7 +222,7 @@ class CQHTTPMessageSegment(MessageSegment["CQHTTPMessage"]):
 
     @classmethod
     def node_custom(
-        cls, user_id: int, nickname: str, content: "CQHTTPMessage"
+        cls, user_id: int, nickname, content: "CQHTTPMessage"
     ) -> "CQHTTPMessageSegment":
         """合并转发自定义节点"""
         return cls(

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,3 +1,7 @@
+import sys
+
+sys.path.append('..')
+
 from alicebot import Bot
 
 bot = Bot(hot_reload=True)


### PR DESCRIPTION
**事件**
---
1. 加入了`message_sent`事件的接收，bot可以响应自己的消息了。

效果:
![image](https://user-images.githubusercontent.com/44714368/225372252-2dfb5493-e38e-4c0c-8179-13e555bdc3fb.png)
![9D6MYVI9$NASL`H8PU)}0F7](https://user-images.githubusercontent.com/44714368/225371929-a5c8991a-8f93-4be3-a0b1-673878552e72.png)

**配置**
---
1. 可以在配置中加入`debug`项，值为`true`时会在日志中显示事件的具体参数。 

配置示例:
```toml
[adapter.cqhttp]
adapter_type = "reverse-ws"
host = "127.0.0.1"
port = 8080
url = "/cqhttp/ws"
api_timeout = 100
debug = true
```

效果:
![%0Y5YK5~)AERW6)TMQ1JV(I](https://user-images.githubusercontent.com/44714368/225370966-cdff2904-34eb-4dc2-a4e3-b4112338f590.png)
