### PR TITLE
修复了示例：天气插件的代码

### DIFF
--- a/docs/guide/plugin-basics.md
+++ b/docs/guide/plugin-basics.md
@@ -217,7 +217,7 @@ class Weather(Plugin):
             return False
         if self.event.type != "message":
             return False
-        return self.event.message.startswith("天气")
+        return self.event.message.get_plain_text().startswith("天气")
 
     @staticmethod
     async def get_weather(city):


### PR DESCRIPTION
修复了示例：天气插件的代码

原代码的 `self.event.message` 为 `{"type": "Source", "id": xxxxx, "time": xxxxxxxxxx}天气`，此时 `self.event.message.startswith("天气")` 无论如何都会返回 `False`，所以 `rule()` 函数最后应当返回 `self.event.message.get_plain_text().startswith("天气")`。