### PR TITLE
[mirai]bug修复：修复mirai中message发送消息quote为True时的异常

### DIFF
--- a/packages/alicebot-adapter-mirai/alicebot/adapter/mirai/event/message.py
+++ b/packages/alicebot-adapter-mirai/alicebot/adapter/mirai/event/message.py
@@ -51,7 +51,7 @@ class FriendMessage(MessageEvent):
                 msg,
                 message_type="friend",
                 target=self.sender.id,
-                quote=self.messageChain[0].id,  # type: ignore
+                quote=self.messageChain[0]['id'],  # type: ignore
             )
         else:
             return await self.adapter.send(
@@ -71,7 +71,7 @@ class GroupMessage(MessageEvent):
                 msg,
                 message_type="group",
                 target=self.sender.group.id,
-                quote=self.messageChain[0].id,  # type: ignore
+                quote=self.messageChain[0]['id'],  # type: ignore
             )
         else:
             return await self.adapter.send(
@@ -91,7 +91,7 @@ class TempMessage(MessageEvent):
                 qq=self.sender.id,
                 group=self.sender.group.id,
                 messageChain=msg,
-                quote=self.messageChain[0].id,  # type: ignore
+                quote=self.messageChain[0]['id'],  # type: ignore
             )
         else:
             return await self.adapter.sendTempMessage(
@@ -111,7 +111,7 @@ class StrangerMessage(MessageEvent):
                 msg,
                 message_type="friend",
                 target=self.sender.id,
-                quote=self.messageChain[0].id,  # type: ignore
+                quote=self.messageChain[0]['id'],  # type: ignore
             )
         else:
             return await self.adapter.send(

--- a/packages/alicebot-adapter-mirai/alicebot/adapter/mirai/event/message.py
+++ b/packages/alicebot-adapter-mirai/alicebot/adapter/mirai/event/message.py
@@ -51,7 +51,7 @@ class FriendMessage(MessageEvent):
                 msg,
                 message_type="friend",
                 target=self.sender.id,
-                quote=self.messageChain[0]['id'],  # type: ignore
+                quote=self.messageChain[0]["id"],
             )
         else:
             return await self.adapter.send(
@@ -71,7 +71,7 @@ class GroupMessage(MessageEvent):
                 msg,
                 message_type="group",
                 target=self.sender.group.id,
-                quote=self.messageChain[0]['id'],  # type: ignore
+                quote=self.messageChain[0]["id"],
             )
         else:
             return await self.adapter.send(
@@ -91,7 +91,7 @@ class TempMessage(MessageEvent):
                 qq=self.sender.id,
                 group=self.sender.group.id,
                 messageChain=msg,
-                quote=self.messageChain[0]['id'],  # type: ignore
+                quote=self.messageChain[0]["id"],
             )
         else:
             return await self.adapter.sendTempMessage(
@@ -111,7 +111,7 @@ class StrangerMessage(MessageEvent):
                 msg,
                 message_type="friend",
                 target=self.sender.id,
-                quote=self.messageChain[0]['id'],  # type: ignore
+                quote=self.messageChain[0]["id"],
             )
         else:
             return await self.adapter.send(


### PR DESCRIPTION
修复插件中调用`self.event.reply('hi',quote=True)` 时报错：

```
2023-05-17 20:25:16.193 | ERROR    | alicebot.log:error_or_exception:15 - Exception in plugin "<emptyclass.emptyclass object at 0x000001C3ABB9F8B0>": AttributeError("'MiraiMessageSegment' object has no attribute 'id'")
```
经调试发现messageChain[0] 形如`{"type": "Source", "id": 2420, "time": xxxxxxxx}`，调用其id需要`messageChain[0]['id']`而非`self.messageChain[0].id`