### PR TITLE
fix(mirai): 修复 Mirai适配器中缺少BotLeaveEventDisband类的问题

### DIFF
--- a/packages/alicebot-adapter-mirai/alicebot/adapter/mirai/event/notice.py
+++ b/packages/alicebot-adapter-mirai/alicebot/adapter/mirai/event/notice.py
@@ -114,6 +114,7 @@ class BotLeaveEventKick(GroupBotEvent):
     type: Literal["BotLeaveEventKick"]
     group: GroupInfo
 
+
 class BotLeaveEventDisband(GroupBotEvent):
     """Bot 所在的群被解散"""
 

--- a/packages/alicebot-adapter-mirai/alicebot/adapter/mirai/event/notice.py
+++ b/packages/alicebot-adapter-mirai/alicebot/adapter/mirai/event/notice.py
@@ -114,6 +114,12 @@ class BotLeaveEventKick(GroupBotEvent):
     type: Literal["BotLeaveEventKick"]
     group: GroupInfo
 
+class BotLeaveEventDisband(GroupBotEvent):
+    """Bot 所在的群被解散"""
+
+    type: Literal["BotLeaveEventDisband"]
+    group: GroupInfo
+
 
 class GroupNoticeEvent(GroupEvent):
     """其他群事件"""


### PR DESCRIPTION
因群主解散bot所在群而产生的[BotLeaveEventDisband事件](https://docs.mirai.mamoe.net/mirai-api-http/api/EventType.html#bot因群主解散群而退出群-操作人一定是群主) 通知在此前会产生 
`
2023-05-20 20:55:58.282 | ERROR    | alicebot.log:error_or_exception:15 - Run adapter MiraiAdapter failed: KeyError('BotLeaveEventDisband')`
错误，而后程序卡死，后续用户消息无法继续处理，系缺少此类导致
