### PR TITLE
[mirai]bug修复：修复其他客户端上下线事件发生的故障

### DIFF
--- a/packages/alicebot-adapter-mirai/alicebot/adapter/mirai/event/notice.py
+++ b/packages/alicebot-adapter-mirai/alicebot/adapter/mirai/event/notice.py
@@ -9,6 +9,7 @@ from .base import (
     MiraiEvent,
     Permission,
     GroupMemberInfo,
+    OtherClientSender,
 )
 
 
@@ -266,3 +267,23 @@ class MemberHonorChangeEvent(GroupMemberEvent):
 
     type: Literal["MemberHonorChangeEvent"]
     action: Literal["achieve", "lose"]
+
+
+class OtherClinetEvent(NoticeEvent):
+    """其他客户端事件"""
+
+    client: OtherClientSender
+
+
+class OtherClientOnlineEvent(OtherClinetEvent):
+    """其他客户端上线"""
+
+    type: Literal["OtherClientOnlineEvent"]
+    kind: Optional[int]
+
+
+class OtherClientOfflineEvent(OtherClinetEvent):
+    """其他客户端下线"""
+
+    type: Literal["OtherClientOfflineEvent"]
+    


### PR DESCRIPTION
[OtherClientOnlineEvent事件](https://docs.mirai.mamoe.net/mirai-api-http/api/EventType.html#其他客户端上线) 以及OtherClientOfflineEvent事件为其他客户端上下线事件，若无此类则会发生故障
```
2023-05-24 20:54:36.395 | ERROR    | alicebot.log:error_or_exception:15 - Run adapter MiraiAdapter failed: KeyError('OtherClientOnlineEvent')
2023-05-24 20:56:17.204 | ERROR    | alicebot.log:error_or_exception:15 - Run adapter MiraiAdapter failed: KeyError('OtherClientOfflineEvent')
```

不过需要注意，调用时这两个事件所给出的参数并不完全相同，`OtherClientOnlineEvent比OtherClientOfflineEvent`事件多出kind参数，根据文档其应该为可空参数。
<html>
<body>
<!--StartFragment-->

名字 | 类型 | 说明
-- | -- | --
client | Object | 其他客户端
client.id | Long | 客户端标识号
client.platform | String | 客户端类型
kind | Long? | 详细设备类型,仅online事件有

<!--EndFragment-->
</body>
</html>

以及，顺带问一下，pr的title应该和git信息同步还是应该像这样中括号标注适配器类型？