### PR TITLE
feat: 给 MessageEvent 类添加用于获取唯一表示符的 get_sender_id method() 方法

### DIFF
--- a/alicebot/event.py
+++ b/alicebot/event.py
@@ -53,6 +53,14 @@ class MessageEvent(Event[AdapterT], Generic[AdapterT]):
     """通用的消息事件类的基类。"""
 
     @abstractmethod
+    def get_sender_id(self) -> Union[None, int, str]:
+        """获取消息的发送者的唯一标识符。
+
+        Returns:
+            消息的发送者的唯一标识符。
+        """
+
+    @abstractmethod
     def get_plain_text(self) -> str:
         """获取消息的纯文本内容。
 
@@ -71,7 +79,6 @@ class MessageEvent(Event[AdapterT], Generic[AdapterT]):
             回复消息动作的响应。
         """
 
-    @abstractmethod
     async def is_same_sender(self, other: Self) -> bool:
         """判断自身和另一个事件是否是同一个发送者。
 
@@ -81,6 +88,7 @@ class MessageEvent(Event[AdapterT], Generic[AdapterT]):
         Returns:
             是否是同一个发送者。
         """
+        return self.get_sender_id() == other.get_sender_id()
 
     async def get(
         self,

--- a/examples/adapters/console_adapter.py
+++ b/examples/adapters/console_adapter.py
@@ -5,7 +5,6 @@
 
 import asyncio
 import sys
-from typing_extensions import Self
 
 from alicebot import MessageEvent
 from alicebot.adapter import Adapter
@@ -19,6 +18,13 @@ class ConsoleAdapterEvent(MessageEvent["ConsoleAdapter"]):
     """
 
     message: str
+
+    def get_sender_id(self) -> None:
+        """获取消息的发送者的唯一标识符。
+
+        Returns:
+            消息的发送者的唯一标识符。
+        """
 
     def get_plain_text(self) -> str:
         """获取消息的纯文本内容。
@@ -35,14 +41,6 @@ class ConsoleAdapterEvent(MessageEvent["ConsoleAdapter"]):
             message: 回复消息的内容。
         """
         return await self.adapter.send(message)
-
-    async def is_same_sender(self, other: Self) -> bool:  # noqa: ARG002
-        """判断自身和另一个事件是否是同一个发送者。
-
-        Returns:
-            是否是同一个发送者。
-        """
-        return True
 
 
 class ConsoleAdapter(Adapter[ConsoleAdapterEvent, None]):

--- a/packages/alicebot-adapter-cqhttp/alicebot/adapter/cqhttp/event.py
+++ b/packages/alicebot-adapter-cqhttp/alicebot/adapter/cqhttp/event.py
@@ -11,7 +11,6 @@ from typing import (
     get_args,
     get_origin,
 )
-from typing_extensions import Self
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.fields import FieldInfo
@@ -131,6 +130,14 @@ class MessageEvent(CQHTTPEvent, BaseMessageEvent["CQHTTPAdapter"]):
         """
         return f'Event<{self.type}>: "{self.message}"'
 
+    def get_sender_id(self) -> Optional[int]:
+        """获取消息的发送者的唯一标识符。
+
+        Returns:
+            消息的发送者的唯一标识符。
+        """
+        return self.sender.user_id
+
     def get_plain_text(self) -> str:
         """获取消息的纯文本内容。
 
@@ -151,17 +158,6 @@ class MessageEvent(CQHTTPEvent, BaseMessageEvent["CQHTTPAdapter"]):
             API 请求响应。
         """
         raise NotImplementedError
-
-    async def is_same_sender(self, other: Self) -> bool:
-        """判断自身和另一个事件是否是同一个发送者。
-
-        Args:
-            other: 另一个事件。
-
-        Returns:
-            是否是同一个发送者。
-        """
-        return self.sender.user_id == other.sender.user_id
 
 
 class PrivateMessageEvent(MessageEvent):

--- a/packages/alicebot-adapter-dingtalk/alicebot/adapter/dingtalk/event.py
+++ b/packages/alicebot-adapter-dingtalk/alicebot/adapter/dingtalk/event.py
@@ -2,7 +2,6 @@
 
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
-from typing_extensions import Self
 
 from pydantic import BaseModel, Field
 
@@ -62,6 +61,14 @@ class DingTalkEvent(MessageEvent["DingTalkAdapter"]):
         """返回 message 字段。"""
         return DingTalkMessage.text(self.text.content)
 
+    def get_sender_id(self) -> str:
+        """获取消息的发送者的唯一标识符。
+
+        Returns:
+            消息的发送者的唯一标识符。
+        """
+        return self.senderId
+
     def get_plain_text(self) -> str:
         """获取消息的纯文本内容。
 
@@ -96,14 +103,3 @@ class DingTalkEvent(MessageEvent["DingTalkAdapter"]):
                 at=at,
             )
         raise WebhookExpiredError
-
-    async def is_same_sender(self, other: Self) -> bool:
-        """判断自身和另一个事件是否是同一个发送者。
-
-        Args:
-            other: 另一个事件。
-
-        Returns:
-            是否是同一个发送者。
-        """
-        return self.senderId == other.senderId

--- a/packages/alicebot-adapter-mirai/alicebot/adapter/mirai/event/message.py
+++ b/packages/alicebot-adapter-mirai/alicebot/adapter/mirai/event/message.py
@@ -2,7 +2,6 @@
 # pyright: reportIncompatibleVariableOverride=false
 
 from typing import TYPE_CHECKING, Any, Dict, Literal, Union
-from typing_extensions import Self
 
 from alicebot.event import MessageEvent as BaseMessageEvent
 from alicebot.message import BuildMessageType
@@ -62,16 +61,13 @@ class MessageEvent(MiraiBaseMessageEvent):
 
     sender: Union[FriendInfo, GroupMemberInfo, OtherClientSender]
 
-    async def is_same_sender(self, other: Self) -> bool:
-        """判断自身和另一个事件是否是同一个发送者。
-
-        Args:
-            other: 另一个事件。
+    def get_sender_id(self) -> int:
+        """获取消息的发送者的唯一标识符。
 
         Returns:
-            是否是同一个发送者。
+            消息的发送者的唯一标识符。
         """
-        return self.sender.id == other.sender.id
+        return self.sender.id
 
     async def reply(
         self,
@@ -244,18 +240,15 @@ class OtherClientMessage(MessageEvent):
 class SyncMessage(MiraiBaseMessageEvent):
     """同步消息"""
 
-    sender: Union[FriendInfo, GroupMemberInfo]
+    subject: Union[FriendInfo, GroupMemberInfo]
 
-    async def is_same_sender(self, other: Self) -> bool:  # noqa: ARG002
-        """判断自身和另一个事件是否是同一个发送者。
-
-        Args:
-            other: 另一个事件。
+    def get_sender_id(self) -> None:
+        """获取消息的发送者的唯一标识符。
 
         Returns:
-            是否是同一个发送者。
+            消息的发送者的唯一标识符。
         """
-        return True
+        return
 
     async def reply(
         self,

--- a/packages/alicebot-adapter-onebot/alicebot/adapter/onebot/event.py
+++ b/packages/alicebot-adapter-onebot/alicebot/adapter/onebot/event.py
@@ -12,7 +12,6 @@ from typing import (
     get_args,
     get_origin,
 )
-from typing_extensions import Self
 
 from pydantic import BaseModel, ConfigDict
 from pydantic.fields import FieldInfo
@@ -169,16 +168,13 @@ class MessageEvent(BotEvent, BaseMessageEvent["OneBotAdapter"]):
         """
         raise NotImplementedError
 
-    async def is_same_sender(self, other: Self) -> bool:
-        """判断自身和另一个事件是否是同一个发送者。
-
-        Args:
-            other: 另一个事件。
+    def get_sender_id(self) -> str:
+        """获取消息的发送者的唯一标识符。
 
         Returns:
-            是否是同一个发送者。
+            消息的发送者的唯一标识符。
         """
-        return self.user_id == other.user_id
+        return self.user_id
 
 
 class PrivateMessageEvent(MessageEvent):

--- a/tests/fake_adapter.py
+++ b/tests/fake_adapter.py
@@ -1,6 +1,5 @@
 import inspect
 from typing import Any, Awaitable, Callable, ClassVar, Optional, Tuple, Union
-from typing_extensions import Self
 
 from alicebot import Adapter, Event, MessageEvent
 
@@ -45,11 +44,11 @@ class FakeAdapter(Adapter[Event[Any], None]):
 class FakeMessageEvent(MessageEvent[FakeAdapter]):
     message: str = "test"
 
+    def get_sender_id(self) -> None:
+        pass
+
     def get_plain_text(self) -> str:
         return self.message
 
     async def reply(self, message: str) -> None:
         pass
-
-    async def is_same_sender(self, other: Self) -> bool:
-        return self.adapter == other.adapter


### PR DESCRIPTION
BREAKING CHANGE: MessageEvent 的子类要求实现 get_sender_id() 方法

MessageEvent 实现用于获取唯一表示符的 get_sender_id() 方法，并且将 is_same_sender() 方法的默认实现更换为调用 get_sender_id() 方法。