### PR TITLE
[Fix] Bugs where cleanup code is not executed correctly when bot exits

### DIFF
--- a/alicebot/bot.py
+++ b/alicebot/bot.py
@@ -236,17 +236,18 @@ class Bot:
 
             await self._should_exit.wait()
         finally:
-            for _adapter in self.adapters:
-                for adapter_shutdown_hook_func in self._adapter_shutdown_hooks:
-                    await adapter_shutdown_hook_func(_adapter)
-                await _adapter.shutdown()
+            with anyio.CancelScope(shield=True):
+                for _adapter in self.adapters:
+                    for adapter_shutdown_hook_func in self._adapter_shutdown_hooks:
+                        await adapter_shutdown_hook_func(_adapter)
+                    await _adapter.shutdown()
 
-            for bot_exit_hook_func in self._bot_exit_hooks:
-                await bot_exit_hook_func(self)
+                for bot_exit_hook_func in self._bot_exit_hooks:
+                    await bot_exit_hook_func(self)
 
-            self.adapters.clear()
-            self.plugins_priority_dict.clear()
-            self._module_path_finder.path.clear()
+                self.adapters.clear()
+                self.plugins_priority_dict.clear()
+                self._module_path_finder.path.clear()
 
     def _remove_plugin_by_path(
         self, file: Path

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -2,7 +2,9 @@
 
 from typing import Any
 
+from anyio.lowlevel import checkpoint
 from fake_adapter import fake_adapter_class_factory, fake_message_event_factor
+from pytest_mock import MockerFixture
 
 from alicebot import Adapter, Bot, Event
 
@@ -51,3 +53,23 @@ def test_bot_run_hook() -> None:
         "adapter_shutdown_hook",
         "bot_exit_hook",
     ]
+
+
+def test_multiple_bot_exit_hook(mocker: MockerFixture) -> None:
+    bot = Bot()
+    mock = mocker.AsyncMock()
+
+    @bot.bot_exit_hook
+    async def bot_exit_hook1(_bot: Bot) -> None:
+        await checkpoint()
+        await mock()
+
+    @bot.bot_exit_hook
+    async def bot_exit_hook2(_bot: Bot) -> None:
+        await checkpoint()
+        await mock()
+
+    bot.load_adapters(fake_adapter_class_factory(fake_message_event_factor))
+    bot.run()
+
+    assert mock.call_count == 2


### PR DESCRIPTION
When bot exits, it sets `_should_exit` (1), so that `Bot._handle_should_exit` will be executed, which calls `cancel_scope.cancel()` (2):

``` Python
class Bot:
    async def _run(self) -> None:
        """运行 AliceBot。"""
        logger.info("Running AliceBot...")

        for bot_run_hook_func in self._bot_run_hooks:
            await bot_run_hook_func(self)

        try:
            for _adapter in self.adapters:
                for adapter_startup_hook_func in self._adapter_startup_hooks:
                    await adapter_startup_hook_func(_adapter)
                try:
                    await _adapter.startup()
                except Exception:
                    logger.exception("Startup adapter failed", adapter=_adapter)

            async with anyio.create_task_group() as tg:
                for _adapter in self.adapters:
                    for adapter_run_hook_func in self._adapter_run_hooks:
                        await adapter_run_hook_func(_adapter)
                    tg.start_soon(_adapter.safe_run)

            await self._should_exit.wait()
        finally: # (3)
            for _adapter in self.adapters:
                for adapter_shutdown_hook_func in self._adapter_shutdown_hooks:
                    await adapter_shutdown_hook_func(_adapter)
                await _adapter.shutdown()

            for bot_exit_hook_func in self._bot_exit_hooks:
                await bot_exit_hook_func(self)

            self.adapters.clear()
            self.plugins_priority_dict.clear()
            self._module_path_finder.path.clear()

    def _handle_exit(self, *_args: Any) -> None:  # pragma: no cover
        """当机器人收到退出信号时，根据情况进行处理。"""
        logger.info("Stopping AliceBot...")
        if self._should_exit.is_set():
            logger.warning("Force Exit AliceBot...")
            sys.exit()
        else:
            self._should_exit.set() # (1)

    async def _handle_should_exit(self, cancel_scope: anyio.CancelScope) -> None:
        """当 should_exit 被设置时取消当前的 task group。"""
        await self._should_exit.wait()
        cancel_scope.cancel() # (2)
```

This makes the finally block in `_run` (3) not executed properly. According to my observation, the execution stops **AFTER THE FIRST `await`**.

Added `with anyio.CancelScope(shield=True):` line to fix this bug. It works on me.